### PR TITLE
split reference before comparing

### DIFF
--- a/f_score.py
+++ b/f_score.py
@@ -19,7 +19,7 @@ def calculate_f_score(corpus, output_text):
 
 with open('non_notation.txt') as f, open('full_annotation.txt') as f1:
     text = f.read()
-    text1 = f1.read()
+    text1 = f1.read().split()   # split on spaces!
     a = len(text)
     b = sp.EncodeAsPieces(text)  
     calculate_f_score(b, text1)

--- a/f_score.py
+++ b/f_score.py
@@ -7,21 +7,19 @@ spm.SentencePieceTrainer.Train('--input=bochan.txt --model_prefix=sentencepiece 
 sp=spm.SentencePieceProcessor()
 sp.Load("sentencepiece.model")
 
-def calculate_f_score(corpus, output_text):
+def calculate_f_score(reference, output_text):
     # Calculate precision, recall, and F-score
-    precision = nltk.precision(set(corpus), set(output_text))
-    recall = nltk.recall(set(corpus), set(output_text))
-    f_score = nltk.f_measure(set(corpus), set(output_text))
+    precision = nltk.precision(reference, output_text)
+    recall = nltk.recall(reference, output_text)
+    f_score = nltk.f_measure(reference, output_text)
     print("Precision:", precision)
     print("Recall:", recall)
     print("F-score:", f_score)
     #return precision, recall, f_score
 
-with open('non_notation.txt') as f, open('full_annotation.txt') as f1:
-    text = f.read()
-    text1 = f1.read().split()   # split on spaces!
-    a = len(text)
-    b = sp.EncodeAsPieces(text)  
-    calculate_f_score(b, text1)
-    f.close()
-    f1.close()
+with open('non_notation.txt') as f_in, open('full_annotation.txt') as f_ref:
+    text_in = f_in.read()
+    reference = f_ref.read().split()    # split into a list
+    output = sp.EncodeAsPieces(text_in) # sp already returns a list
+    calculate_f_score(set(reference),
+                      set(output))

--- a/mecab_score.py
+++ b/mecab_score.py
@@ -4,23 +4,21 @@ import MeCab
 #nltk.download("punkt")
 from nltk.metrics import precision, recall, f_measure
 
-def calculate_f_score(corpus, output_text):
+wakati = MeCab.Tagger("-Owakati")
+
+def calculate_f_score(reference, output_text):
     # Calculate precision, recall, and F-score
-    precision = nltk.precision(set(corpus), set(output_text))
-    recall = nltk.recall(set(corpus), set(output_text))
-    f_score = nltk.f_measure(set(corpus), set(output_text))
+    precision = nltk.precision(reference, output_text)
+    recall = nltk.recall(reference, output_text)
+    f_score = nltk.f_measure(reference, output_text)
     print("Precision:", precision)
     print("Recall:", recall)
     print("F-score:", f_score)
     #return precision, recall, f_score
 
-with open('non_notation.txt') as f, open('full_annotation.txt') as f1:
-    text = f.read()
-    text1 = f1.read().split()   # split on spaces!
-    a = len(text)
-    wakati = MeCab.Tagger("-Owakati")
-    b = wakati.parse(text).split()  
-    print(b)
-    calculate_f_score(b, text1)
-    f.close()
-    f1.close()
+with open('non_notation.txt') as f_in, open('full_annotation.txt') as f_ref:
+    text_in = f_in.read()
+    reference = f_ref.read().split()       # split into a list
+    output = wakati.parse(text_in).split() # split into a list
+    calculate_f_score(set(reference),
+                      set(output))

--- a/mecab_score.py
+++ b/mecab_score.py
@@ -16,7 +16,7 @@ def calculate_f_score(corpus, output_text):
 
 with open('non_notation.txt') as f, open('full_annotation.txt') as f1:
     text = f.read()
-    text1 = f1.read()
+    text1 = f1.read().split()   # split on spaces!
     a = len(text)
     wakati = MeCab.Tagger("-Owakati")
     b = wakati.parse(text).split()  


### PR DESCRIPTION
otherwise you're comparing with the baseline of "every single character is a word":


```python
>>> with open("full_annotation.txt") as f:
...     print(set(f.read()))
...
{'ｗ', '宙', '業', 'ｆ', '方', '順', '指', '交', '雪', '示', '利', 'ピ', 'ズ', '第', '貼', '馬', 'う', '鳥', '』', '貨', '校', '道', '出', '人', 'Ｃ', '会', '償', '之', '中', '策', '生', '識', '務', '存', '＋', '当', '－', '個', '念', '通', 'エ', '能', 'か', '典', 'ゲ', '律', '防', '魂', '下', '蒸', '少', '敵', '候', 'め', '長', '国', 'ｙ', 'Ö', '強', '０', '誓', '号', '憲', '立', 'ル', 'パ', 'ェ', '判', '毛', '来', 'じ', '弁', 'ま', '述', '○', 'ｘ', '住', '差', '型', '司', 'オ', '勇', '白', '青', '社', '家', '乗', 'Ｎ', '考', '配', '絵', '了', '東', '使', '州', '町', 'ラ', '由', '認', 'サ', '位', '沖', '骨', '南', 'ｏ', '川', '獣', '互', '平', '４', '岡', '手', '応', '単', '子', '伝', 'ら', '良', '究', '芸', '領', '告', '鮮', 'Ｉ', '映', '北', '回', '願', '別', '守', 'ケ', '再', '催', 'ダ', 'と', '観', '明', '束', '株', 'ゼ', '響', '芽', '始', 'ギ', 'ｐ', '先', 'チ', 'ヘ', '保', 'よ', '杉', '営', '時', '．', '優', 'ず', '²', '決', '言', 'ウ', '々', '話', '験', '理', '量', '演', 'テ', '津', '寛', '経', '熊', '暦', 'ザ', '昭', '布', 'ャ', '形', '雑', '照', '含', '甲', '思', '拠', 'ｋ', '。', 'せ', '隊', '、', '怪', '題', '赤', ' ', '渡', '否', 'み', '寄', '３', '盛', '餓', '術', '治', '登', 'Ｓ', '写', '刺', '石', 'は', '世', '千', '範', '幡', '織', 'ュ', '霊', '珍', '線', 'Ｖ', '…', '収', '踏', '柄', '呼', 'ひ', '実', '終', 'ア', '士', '画', 'へ', '与', '阿', 'Ｅ', '水', '引', '葉', '『', '賛', '困', '試', '鋭', '打', '高', '用', '続', '急', 'Ｆ', '義', 'ｎ', 'ジ', '％', 'ノ', 'ヨ', '炭', '花', '楽', '箇', 'Ｔ', '秩', '効', '辺', 'ホ', 'デ', '陰', '録', 'ｃ', '卯', '印', '確', '御', '和', '倍', '安', '部', 'お', '心', '虜', '独', 'る', '供', '龍', 'バ', '達', 'ゴ', '遵', '舞', '接', '河', 'Ｒ', '露', '序', '遠', '味', '最', '谷', 'Ｇ', 'ソ', '放', '構', '米', 'ワ', '責', '勢', '発', '輔', '友', '組', '技', '選', '謀', '２', 'も', '産', 'セ', '自', '宗', '紀', '\n', 'ユ', '販', '遣', ' レ', '定', '章', '断', '全', 'ｇ', '韓', '持', '１', '血', '散', '春', '省', 'き', '蛮', '邦', '駅', '具', '対', '正', '鹿', '聞', '八', '女', '臨', '他', '減', 'ペ', '巻', 'フ', '聖', '公', '状', '７', '鶴', 'ム', '常', '光', '同', '，', '離', 'て', '猾', '例', 'Ｘ', '気', '伊', '工', '央', '荒', '的', '規', '節', '革', '四', '担', 'モ', '満', '行', 'ー', 'れ', '転', '塗', '５', '学', '狼', '二', '流', '府', 'Ａ', '域', '賞', 'ス', 'ッ', '現', '原', '任', 'カ', '支', 'Ｌ', '海', '証', '境', '論', '梯', '求', '火', '撒', '勝', '江', '香', 'ナ', '郎', '\u3000', '両', '黒', 'Ｕ', '市', '員', '太', '解', '残', '要', 'ニ', '遼', '園', '近', 'そ', 'ボ', '様', 'ポ', '芥', '日', '績', 'ほ', '装', 'ィ', '頭', '王', '点', 'Ｏ', 'で', '役', '夏', '旧', '着', '所', '歌', '沢', 'ｍ', '迎', '源', '値', '傾', '）', '約', '改', '在', '以', '山', '慢', 'ネ', '砂', '完', '結', '拒', '教', '右', '建', '複', '美', 'ロ', '似', 'グ', '京', '癌', 'ｌ', '囲', '議', 'ド', '都', '就', '胞', 'ミ', '付', '合', '横', '批', 'ｖ', '軸', '式', '概', '陸', '板', '「', '均', '並', '備', '望', '重', '件', '象', '妻', '棘', '看', '桁', '衝', '面', '目', '階', '法', '俳', '後', '算', '三', '偶', '：', 'ク', '歩', '盾', '察', '池', '民', '佳', '遺', '野', '併', '倭', '提', '宮', '略', '故', '糸', 'シ', '架', '退', '関', 'Ｄ', '態', '左', '度', '積', '門', 'ｓ', '性', '投', '上', '数', '測', 'り', '※', 'ゃ', '競', '棟', '（', '託', '岬', '研', '際', '質', '小', '代', '」', '震', '主', '雄', '足', '緑', '朝', '檀', '直', '軽', '根', '９', '逃', 'ト', 'を', '月', '新', '各', '予', '口', '容', '起', '賜', '基', '止', '農', 'ん', '療', 'ち', '県', '難', 'し', 'Ｐ', '訳', '亡', 'ば', '身', '脈', '祈', '品', '広', '集', '戦', 'こ', '尉', '英', '載', '噴', '多', 'Ｙ', '番', '制', 'に', '機', '養', '弓', '混', 'い', '共', '検', '化', 'の', '仏', '報', '肺', '撮', 'メ', '包', '片', '間', '九', '維', '外', '群', '屋', 'く', '診', ' 派', '／', 'Ｍ', '売', '病', '初', '商', '覧', '加', '作', '好', '記', '詔', '諾', 'ョ', '名', '置', 'Ｚ', '元', '参', '粒', '換', '展', 'Ｈ', '介', 'ハ', '歳', '拍', '俘', 'Ｊ', '得', '者', '局', '唄', '物', '信', '幹', '６', '除', '慕', '誕', 'ｔ', '必', '列', 'プ', '院', '等', '移', 'や', '飲', '意', '場', '密', '儁', '不', '知', '本', '館', 'ａ', '端', 'タ', '締', 'つ', '粘', '古', 'ォ', '耕', '図', 'ｒ', '土', 'ゅ', '～', '柱', '連', '大', '史', '西', '・', 'ビ', '問', '況', '周', 'っ', '評', '資', 'ブ', 'げ', '襲', 'ｅ', '政', '瀬', '棋', '年', '角', '段', '表', 'べ', '電', 'ぞ', 'ン', 'わ', '属', '帯', '廃', '変', '斧', 'ぱ', '無', '賀', '銀', '挙', 'イ', '見', '速', '漫', '果', '一', '酒', 'ｈ', '側', '振', '区', '捧', '項', '＆', 'え', '鏡', 'ヴ', '晴', '体', 'ヤ', '降', '庫', '８', 'な', '受', '潮', '分', '島', '文', '次', '可', '音', '壁', '界', '風', '嶋', '索', '地', '込', '設', 'ガ', 'ベ', '補', '条', '静', '争', '著', '率', '携', '請', '入', 'キ', '阪', 'た', '田', '鉄', '死', '版', '科', 'す', '向', '曜', '扱', '計', '称', '仕', 'び', 'け', '前', '影', '車', '漢', 'ね', '系', '貫', '準', '綬', '底', '延', '待', '統', '未', '俗', '塾', '色', '動', '；', '書', '宣', '字', '客', '路', '料', 'ｕ', '旅', 'コ', '事', 'ツ', 'ヒ', '情', '超', '松', 'が', 'ぎ', 'ｉ', '有', '仮', '開', '細', '成', '素', '橋', '梁', '授', '内', '狡', 'ァ', 'リ', 'だ', 'む', '宇', 'あ', 'さ', '語', '環', '運', '進', '程', '期', 'ど', 'ぼ', '限', 'マ', '剥'}

>>> with open("full_annotation.txt") as f:
...     print(set(f.read().split()))
...
{'ずる', '交雑', 'ＥＵＳＯ', '業', 'ジロー', '集散', '装置', '１９８８', 'フィーバー', '方', '順', '判定', 'ＡＸ２８６', '指', '公式', '宣誓', 'ターミナル', 'および', '雪', '示', '同時', 'ＵＬＴＲＡＭＡＮ', 'レズリー', '義雄', '人物', '発生', '２００６', '当時', '第', 'カトリック', 'う', 'あと', '開業', '』', 'ビデオ', '歌手', '校', '出', '開始', '平成', '人', '付近', '美唄', '利用', '生物', 'ＰＣ', '１８９５', '中', '１９４８', '１９３３', '朝鮮', '群発', 'ほぼ', 'こう', '＋', '求め', 'りそな', '－', '出資', '明治', '名称', '通', '連動弁', '重んじ', 'か', '５６', '大きな', 'くる', '海底', 'イー', 'すべて', '敵', '市松', '中東', '予定', 'パーリ', '粒子', '２００８', 'ポリアセタール', '倭国', '電気', '龍之介', '国', 'この', '改革', '準々', '他言語', '鳥山', '日立', '０', 'ジャ', '研究', '珍し', '先住', '新た', '国家', '号', '存在', 'ボーイ', 'スミス', '演歌', '美学', '東北', '分散', '芥川', '制御', '伝道', 'ドーム', 'じ', '完了', 'ま', '○', '明らか', '地域', 'あげ', 'ここ', '型', '困難', '統計', '司', '一貫', '白', '青', 'ＭＺ', 'ティヴェント', '運転', 'Ｎ', '知識', '試合', '女優', 'ばら撒', '共同', '絵', '北原町', '寄生', '石炭', '独立', '人民', '使', '退廃', '明示', '商用', '源義', '四国', '収録', '選出', '３００８', '１９７８', '参照', '古典', 'Ｌｏｃａｌ', '位', '沖', '南', '川', '獣', '熊野川', '４', '勝手', '手', '当駅', 'マキビシ', '応', '維 持', '紀勢', '子', '御前', 'ひと', '不可', 'じん', '行政', 'ため', '伝', 'ら', '無償', '請願', '漢訳', '英語', 'いずれ', '北', '回', '再', '別', '環境', '移行', '太守', '河本', '同一', 'と', 'ＡＴＭＪ', '同年', '３４', '明', '１９８９', '周辺', '支配', '工事', '階乗', '表現', 'アントラーズ', '否定', '実験', '最終', '先', 'ＰＯＭ', 'よ', '事故', '作家', '江刺', '文字', '時', '．', 'ず', '²', 'なお', 'Ｍａｈｒａ', '蒸気', 'シンドバッド', '新約', '概念', '踏襲', '量', '軽減', '南海', 'あとがき', 'スロット', 'オール', 'カートリッジ', 'ウィリアム', '経', '暦', '運行', '耕地', '形', '範囲', '含', '。', '東京', '、', '憲章', '赤', '着手', '中心', '前出', '項目', '賛否', '戦争', '受賞', '鉄道', '３', 'うち', 'ＯＶＡ', '変身', '義務', 'プラットフォーム', '結果', '気候', 'それぞれ', '事実', '設置', '単に', '引き分け', ' は', '関数', 'あさひ', '肺癌', '伊東', '共和', '計算', '杉並', '５８', '線', 'デザイン', 'Ｖ', '…', '限定', '合同', '残り', '地区', 'Ｓｏｆｔｗａｒｅ', '１９９２', '呼', '構成', '締結', '産業', '在来', '主体', '出発', '候補', 'へ', 'ＮＥＣ', '２００５', 'つから', 'Ｅ', '水', '会津', 'ポスト', '『', '外壁', '１３１', '鋭', '理化学', '高', '１９３７', '檀紀', '用', 'ｎ', '％', '可能', 'パレスティナ', 'られ', 'ＳＦ', 'フェルマー', '主に', '地震', '科学', 'メジャー', '段階', 'ＯＶ', 'ねらー', '通常', '１２', '組織', '聖書', 'ＪＡＳＲＡＣ', 'マン', '終結', '入学', '場合', 'こと', 'コロンバス', '昭和', '規律', '解放', '配線', 'フォン', '８００', 'その', 'ホーム', 'イメージ', '１９９０', '現役', '海側', '倍', 'これ', 'スコアレス', '部', '著し', 'ドイツ', 'お', '方向', 'る', '問題', 'サイト', '本州', '遵', '舞', '日本', '作品', '開園', '流域', '話題', '２０１０', '未満', '制作', 'ＩＥＥＥ', '方法', '対象', 'さらに', '療養', 'モンテネグロ', 'ボールド', '部門', 'デッキ', '怪死', '１９４５', '要求', 'キロ', 'チャンピオンシップ', 'よう', '米', '理事', '橋梁', '起点', '組', '２', 'も', 'キリ スト', '使用', '表記', 'しかし', '良く', '重要', '望遠', 'バイト', '元日', 'Ｄｅｎｓｉｔｙ', '銀行', '機関', '速度', 'する', 'ＮＣＲ', '２４０', '都市', '持', '１', 'など', '立体', '春', '細胞', '省', '高架', '１５', '駅', 'き', '併せ持', '対', '八', '定理', '他', '宣伝', '合併', 'ある', 'ドロー', '７', 'ヒット', '小学', '元年', '年間', '同', '，', '上記', '旅客', 'て', 'コミュニケーション', '例', '貼り付け', '条件', '得意', '統制', '軸受', '体系', '歩行', '１４', '次元', '変数', '的', '例えば', '連合', 'ｒａｒｒ', '主演', 'ＭＳＥ', '生成', '節', '棋士', '１０８７', 'シリーズ', '帯方', '担', '批判', 'コレクション', '１１８６', '戦隊', '地学', '新人', '大学', '行', 'マルチ', '統合', '仮授', '仏典', 'ハートフル', '公立', 'れ', '集合', '５', '学', '未来', 'マリリン', 'ひかり', '大阪', '衝動', 'ＪＲＡ', 'Ｎｅｉｌ', 'ネクサス', '情報', '二', 'ＬＭＧ', 'Ａ', 'セルビア', '賞', 'ＬａＬａＤＸ', '１９４０', '本社', '離合', 'データ', '梯', '会社', '迎え', '勝', '用い', '谷口', '急変', 'アクセス', '少年', 'ネジ', '荒川', '香', 'アルバム', 'エレベータ', '市', '黒', 'スパル', '員', '約束', '解', '１８０２', '満た', '遺伝', '世界', 'ＮＡＳＡ', 'メンデル', '型番', '条約', '遼', '最も', '園', '制定', '東海', '１９８０', 'スポンサー', '診断', 'また', '日', '２００２', 'でき', 'ＡＸ３８６', '音楽', '必要', 'ガーフィールド', 'スターズ', '点', '文様', 'オムロン', '役', 'で', '根拠', 'Ｈａｒｖｅｓｔ', 'コマ', '発効', '旧', 'キュチュク', '鶴岡', '大韓民国', '所', 'ｍ', '値', 'ちゃん', '回転', '）', '名古屋', '約', 'ワン', '中央', '祈り', '称号', '８０２', '２００４', 'すぎ', '長期', '拒', 'ロボット', '接着', '教', 'ナチス', '連続', '建', '右', '東名', '言葉', '状況', '以下', '重訳', '併用', '誕生', '学会', 'ゲーム', '宗谷', '学院', '照明', '区画', 'ÖＳＳ', 'から', '並べ', 'グ', '都', 'マードック', 'ユニホーム', 'チリ', '江ノ島', 'けぱけぱ', '区間', '１００', '動産', '設備', '式', 'ディレクトリ', 'キャンペー ン', '陸', '和歌山', '上野', '「', '国境', '印綬', 'アドバンス', '決勝', '政府', '記念', 'まで', '文治', '鹿島', '件', '妻', '棘', '記録', 'コード', '１９９９', '目', '法', '八幡', '日露', '初めて', '後', '三', '学校', 'ノウハウ', '：', '各地', '表中', '内部', '蛮勇', '盾', '仕様', '平均', '保証', 'アルゴリズム', 'とおり', '受け', '思考', '数字', '提供', '対偶', '放映', '貨物', '漫画', '車止め', 'Ｙｏｕｎｇ', '宮', '略', '番線', '１１', '池上', 'ＡＴ', '定義', '儁ら', 'いちらん', '関', '個人', '死者', 'ディズニー', '左', 'イベント', '度', 'パラドックス', '大統領', '決定', '２５', '本線', '性', '数', '上', '臨時', 'り', '※', 'アラビア', '高校', '（', '米国', '表示', '毛糸', '棟', '岬', 'ヒーロー', 'シンボル', '際', '全国', '以降', '告知', '容態', '基本', '様々', '電子', '広告', '正始', '」', '代', '阿賀', '打ち 上げ', '小', '列車', 'アニメ', '意味', 'いち', 'プログラム', 'エネルギー', '緑', '市章', '本体', '農園', '朝', '高橋', '９', 'のみ', '逃', 'を', '月', '新', '傾向', '１０', '素晴らし', '鉄骨', '文庫', '物的', 'ＡＸ', '名乗', '収集', '責任', '横渡', '粘土', '発足', '素数', '開発', 'シネマ', '砂絵', '文脈', '県', '互換', '分布', 'し', 'リヒャルト', 'メトロ', '登録', '新聞', '事業', '現在', '農業', '３３００', '入試', '両論', 'ば', '春夏', '所沢', '不満', '明確', '通称', '品', 'ＪＣｒｅａｔｏｒ', '１８', '広', '多く', 'スーパー', '直立', 'シネ', '尉', '挙が', '剥げ', '多', 'ソフト', '密度', '向か', '１９９７', 'ヴァイツゼッカー', 'に', '機', '映画', '慢性', '弓', '倭王', 'い', '化', '形式', '由来', '露土間', 'の', '技法', '初代', '対決', '撮', '沖合', '１４０', '間', '減速', '１日', '霊魂', '詔書', '１９８３', '当た', 'ランナー', '法的', 'く', '捧げ', '延長', '／', '正式', '工業', '具体', '初', '商', 'ギリシア', '文明', '新設', '演', '資本', '完成', '作', 'カイ', '上部', 'かっ', '名', '置', '県境', '元', '資料', '発達', '領土', 'サザン', '差し込', '俳優', 'ソリューションズ', 'だっ', 'モーガン', '競馬', 'おけ', '展', '有名', 'Ｈ', '歳', '安全', '人的', '２２', '与え', '記述', 'Ａｐｐｒｏｘｉｍａｔｉｏｎ', '要素', '敵対', 'Ｊ', '者', '花巻', '３９', '九州', '連邦', '表わ', '支線', '防御', '主義', '芸術', 'しれ', 'ヨーロッパ', '強制', '６', '除', 'アルマラ', '慕', 'イギリス', 'ＡＴＭ', '作新', '（株）', '列', '海戦', 'ロード', '千住', '餓狼', '新宮', '重次郎', 'や', '廃止', '三重', '主要', '場', '俘虜', '改良', 'デビュー', 'ナル', '知', '不', '計画', 'Ｘｉｎｏｘ', '館', '１９８２', '１９３１', '連載', 'スタンド', '三角', '複線', 'なか卯', 'つ', '経営', '大陸', '遺産', '佳作', '例外', '上位', '古', '図', '２８', '～', '柱', '局所', '大', '史', '派遣', '始ま', '紀州', '技術', '等し', '頭部', 'むき出し', 'ラインナップ', 'ＶＨＳ', 'バトル', '・', '競争', 'バッシング', '大宮間', '宗教', 'っ', '運用', '大和', '友好色', '年', '土地', '表', 'べ', '性質', '絵柄', 'わ', '開催', '属', 'アニメーション', 'アメリカ', '平面', '自由', '斧', 'ミュンヘン', '成績', '無', '寛治', 'ライブ', '提携', 'ベスト', 'ビクター', '俗称', '振り回', '後退', 'まま', '塗装', '国際', '観測', '銀', '加速', '噴火', '人間', '見', '評議', '証拠', '風潮', '看板', '受諾', 'トルコ', '一', 'ＰＲＯＪＥＣＴ', '水沢', 'サンスクリット', '区', '＆', '項', '民主', 'ｏｎｅ', '鏡', '片瀬', 'マーク', '亡くな', '体', '受験', '８', 'な', '１９８４', '行な', 'それ', '設計', '次', 'ダイヤグラム', 'せんじゅう', 'ダイラ', '方程', '甲子', '一覧', '１９８５', '挙げ', '嶋', 'アフリカ', '田端', '検索', 'マラード', '組み合わせ', '１９６０', '高速', '同社', '信託', '条', '待機', '静', '実写', 'いえ', '電化', '入', 'Ｍａｈｒｉ', 'た', '発売', '秩序', '盛ん', '６００００', '２００９', '芽子', '内包', '版', '人気', 'す', '扱', '線路', '前', 'より', 'オリジナル', '車', '投げ', '認め', '優勝', '系', '略称', 'ワニ', '西ドイツ', 'もしくは', 'ＬＧＳ', 'キャラクター', '作り上げ', '入院', '交差', 'ＧＵＩ', '日曜', 'モンロー', 'ハドソン', '運営', 'ランド', '述べ', '下賜', '要約', '就任', '改称', '塾', '動', '系列', '；', '書', '地方', 'ｋｍ', '直接', '箇所', '事', '拍子', '確率', 'イエメン', '大賞', '宇宙', '超', 'ａｕ', '販売', 'が', 'もの', 'コミック', '狡猾', '幹線', '大輔', '含め', 'アーネスト', 'ゴールド', '病院', '観察', '存続', '光子', 'エンジン', '面積', '南美唄', 'ホーン', 'ＨＦＯＲＴＲＡＮ', '陰謀', '北海道', '影響', 'ＨＲ', '策定', 'ブランド', '千代田', '混血', 'ガス', '飲酒', '内', '現象', '８０００', 'だ', '桁数', 'む', '陸上', 'ファミコン', 'さ', 'あ', '語', '進', '近似', 'レンズ', '期', '大戦', '１９６２', 'ゲージ', '線型'}
```


```sh
$ python3 f_score.py
sentencepiece_trainer.cc(177) LOG(INFO) Running command: --input=bochan.txt --model_prefix=sentencepiece --vocab_size=8000 --character_coverage=0.9995

[…lots of noise…]

Precision: 0.251105216622458
Recall: 0.2506619593998235
F-score: 0.2508833922261484

$ python3 mecab_score.py
Precision: 0.8738197424892704
Recall: 0.8984995586937334
F-score: 0.885987815491732
`` 